### PR TITLE
Close connections manually

### DIFF
--- a/src/blockchain_processor.py
+++ b/src/blockchain_processor.py
@@ -112,7 +112,9 @@ class BlockchainProcessor(Processor):
         postdata = dumps({"method": method, 'params': params, 'id': 'jsonrpc'})
         while True:
             try:
-                respdata = urllib.urlopen(self.bitcoind_url, postdata).read()
+                connection = urllib.urlopen(self.bitcoind_url, postdata)
+                respdata = connection.read()
+                connection.close()
             except:
                 print_log("cannot reach bitcoind...")
                 self.wait_on_bitcoind()
@@ -589,7 +591,9 @@ class BlockchainProcessor(Processor):
 
         while True:
             try:
-                respdata = urllib.urlopen(self.bitcoind_url, postdata).read()
+                connection = urllib.urlopen(self.bitcoind_url, postdata)
+                respdata = connection.read()
+                connection.close()
             except:
                 logger.error("bitcoind error (getfullblock)")
                 self.wait_on_bitcoind()


### PR DESCRIPTION
This is a required change to run electrum-server on PyPy.

On PyPy the garbage collector works differently than it does on CPython. This in turns causes the connections to stay open and to eat up all your sockets in no time.

This change closes the connections (and in turn the sockets) right after reading the data out of it.
